### PR TITLE
Fixes #1025

### DIFF
--- a/public_html/css/custom-bootstrap.css
+++ b/public_html/css/custom-bootstrap.css
@@ -459,7 +459,9 @@ abbr {
 
 .btn-group {
     margin-bottom: 10px;
-}.panel {
+    display: inline-block;
+}
+.panel {
      padding: 15px;
      margin-bottom: 20px;
      background-color: #ffffff;


### PR DESCRIPTION
The yellow/red .btn-group on the left was overlapping the blue buttons in right column.
